### PR TITLE
Guard against boolean return value from get_latest_events()

### DIFF
--- a/classes/WidgetManager.php
+++ b/classes/WidgetManager.php
@@ -70,7 +70,7 @@ class WSAL_WidgetManager {
 		$results = Alert_Manager::get_latest_events( $this->plugin->settings()->get_dashboard_widget_max_alerts(), true );
 
 		?><div>
-		<?php if ( ! count( $results ) ) : ?>
+		<?php if ( ! is_countable( $results ) || ! count( $results ) ) : ?>
 			<p><?php esc_html_e( 'No events found.', 'wp-security-audit-log' ); ?></p>
 		<?php else : ?>
 			<table class="wp-list-table widefat" cellspacing="0" cellpadding="0"


### PR DESCRIPTION
We've observed an issue in some of our test environments where the `Alert_Manager::get_latest_events` method returned `false` (indicating that connectivity was lost), which is a TypeError on recent versions of PHP because `count` requires its argument to be countable.

This patch ensures that the admin will load even if the get_latest_events method returns false.