### PR TITLE
Fixes a PHP warning 

### DIFF
--- a/classes/Helpers/class-widget-manager.php
+++ b/classes/Helpers/class-widget-manager.php
@@ -72,6 +72,10 @@ if ( ! class_exists( '\WSAL\Helpers\Widget_Manager' ) ) {
 		public static function render_widget() {
 			$results = (array) Alert_Manager::get_latest_events( Settings_Helper::DASHBOARD_WIDGET_MAX_ALERTS, true );
 
+			if ( false === $results[0] ) {
+				return;
+			}
+
 			?><div>
 			<?php if ( ! count( $results ) ) { ?>
 			<p><?php esc_html_e( 'No events found.', 'wp-security-audit-log' ); ?></p>


### PR DESCRIPTION
The code here it's expecting an array
https://github.com/wpwhitesecurity/wp-security-audit-log/blob/master/classes/Helpers/class-widget-manager.php#L73 

But in some cases it receives `false` 

https://github.com/wpwhitesecurity/wp-security-audit-log/blob/master/classes/Controllers/class-alert-manager.php#L1055 